### PR TITLE
Fixes TypeError issue in Ember 1.10

### DIFF
--- a/lib/ember-pusher/initializer.js
+++ b/lib/ember-pusher/initializer.js
@@ -22,7 +22,7 @@ function initialize() {
       options = application.PUSHER_OPTS;
 
       Ember.assert("You need to provide PUSHER_OPTS on your application", options);
-      Ember.assert("You need to include the pusher libraries", Pusher);
+      Ember.assert("You need to include the pusher libraries", typeof Pusher !== 'undefined');
       pusher = new Pusher(options.key, options.connection);
       pusherController.didCreatePusher(pusher);
 


### PR DESCRIPTION
After upgrading to Ember 1.10.0 the Application complains about "Uncaught TypeError: undefined is not a function". For some unknown reason Ember.assert also seems to execute the Pusher function. To overcome this I am explicitly checking if Pusher is undefined.