### PR TITLE
Added option to dasherize channel names, including some tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 dist
 npm-debug.log
 node_modules
+/tmp

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
 # 0.1.0
 
 * Getting started
+
+* Added option to dasherize channel names [Michael Catlin] (malrase@gmail.com)

--- a/README.md
+++ b/README.md
@@ -93,6 +93,28 @@ var YourController = Em.Controller.extend(EmberPusher.Bindings, {
 keep your controller's methods looking consistent. Event handlers are tracked
 and torn down when a controller is destroyed.
 
+### Channels with Dashes
+
+In some cases, Pusher requires a channel name that includes a dash – for example in `presence-`
+or `private-` channels. Due to ember-cli being very strict with JavaScript syntax, it is not
+possible to use a dash in the channel names when configuring your `PUSHER_SUBSCRIPTIONS`.
+
+To get around this, we allow the `PUSHER_OPTS` option of `dasherizeChannel`. When set to true,
+the channel name in `PUSHER_SUBSCRIPTIONS` is dasherized. For instance, this is how you would build
+a simple presence controller.
+
+```javascript
+PUSHER_OPTS: { key: 'foo', dasherizeChannel: true }
+
+...
+var YourController = Em.Controller.extend(EmberPusher.Bindings, {
+  PUSHER_SUBSCRIPTIONS: {
+    presenceMessages: ['member_added'],
+  },
+});
+```
+
+
 
 That's about it! When events come in, they should be triggered on the listening controllers.
 It should be noted that event bubbling will all work as expected, so you can actually implement
@@ -149,7 +171,7 @@ Indeed.
 ```javascript
 App.MyController = Ember.Controller.extend(EmberPusher.Bindings, {
   PUSHER_SUBSCRIPTIONS: {
-    my-channel: ['pusher:subscription_succeeded']
+    myChannel: ['pusher:subscription_succeeded']
   },
 
   actions: {

--- a/lib/ember-pusher/bindings.js
+++ b/lib/ember-pusher/bindings.js
@@ -10,6 +10,9 @@ var Bindings = Ember.Mixin.create({
     target = this;
     Object.keys(target.PUSHER_SUBSCRIPTIONS).forEach(function (channelName) {
       var events = target.PUSHER_SUBSCRIPTIONS[channelName];
+      if(target.pusher.get("dasherizeChannel")) {
+        channelName = channelName.dasherize();
+      }
       target.pusher.wire(target, channelName, events);
     });
   },

--- a/lib/ember-pusher/controller.js
+++ b/lib/ember-pusher/controller.js
@@ -50,6 +50,7 @@ var Controller = Ember.Controller.extend({
   connection: null,
   isDisconnected: true,
   isConnected: Ember.computed.not('isDisconnected'),
+  dasherizeChannel: false, // Initializer overrides this from a pusher option
 
   init: function() {
     this._super();

--- a/lib/ember-pusher/initializer.js
+++ b/lib/ember-pusher/initializer.js
@@ -25,6 +25,7 @@ function initialize() {
       Ember.assert("You need to include the pusher libraries", typeof Pusher !== 'undefined');
       pusher = new Pusher(options.key, options.connection);
       pusherController.didCreatePusher(pusher);
+      pusherController.set("dasherizeChannel", !!options.dasherizeChannel);
 
       application.inject('controller', 'pusher', dict);
       application.inject('route', 'pusher', dict);
@@ -34,4 +35,3 @@ function initialize() {
 }
 
 export { initialize };
-

--- a/test/lib/authenticated_test.js
+++ b/test/lib/authenticated_test.js
@@ -1,0 +1,44 @@
+describe("AuthenticateController", function() {
+  var App, targetAuthController, pusherController, channelName, bindings;
+
+  var FakeAuthController = Em.Controller.extend(EmberPusher.Bindings, {
+    PUSHER_SUBSCRIPTIONS: {
+      presenceMessages: ['event-one', 'event-two']
+    },
+    eventOne: function(){ return "event-one-fired"; },
+    eventTwo: function(){ return "event-two-fired"; }
+  });
+
+  Ember.Application.initializer({
+    name: "registerFakeAuthController",
+    initialize: function(container, application) {
+      container.register('controller:fake-auth', FakeAuthController);
+      targetAuthController = container.lookup('controller:fake-auth');
+    }
+  });
+
+  App = Ember.Application.create({
+    PUSHER_OPTS: { key: 'foo', dasherizeChannel: true }
+  });
+
+  before(function(){
+    pusherController = App.__container__.lookup('pusher:main');
+    pusherController.get('connection').connection.socket_id = '1234';
+    channelName = 'presence-messages';
+    bindings = pusherController.get('bindings');
+  });
+
+  describe("wire", function() {
+    it("initializes channelName in the bindings hash", function() {
+      assert.ok(pusherController.get('bindings')[channelName], "Creates a channel name");
+    });
+  });
+
+  describe("channelFor", function() {
+    it("returns a channel object", function() {
+      var channel = pusherController.channelFor(channelName);
+      assert.ok(channel, "channel defined");
+    });
+  });
+
+});

--- a/test/lib/controller_test.js
+++ b/test/lib/controller_test.js
@@ -1,26 +1,25 @@
-var App, targetController, pusherController, channelName, bindings;
-
-var FakeController = Em.Controller.extend(EmberPusher.Bindings, {
-  PUSHER_SUBSCRIPTIONS: {
-    craycraychannel: ['event-one', 'event-two']
-  },
-  eventOne: function(){ return "event-one-fired"; },
-  eventTwo: function(){ return "event-two-fired"; }
-});
-
-Ember.Application.initializer({
-  name: "registerFakeController",
-  initialize: function(container, application) {
-    container.register('controller:fake', FakeController);
-    targetController = container.lookup('controller:fake');
-  }
-});
-
-App = Ember.Application.create({
-  PUSHER_OPTS: { key: 'foo' }
-});
-
 describe("Controller", function() {
+  var App, targetController, pusherController, channelName, bindings;
+
+  var FakeController = Em.Controller.extend(EmberPusher.Bindings, {
+    PUSHER_SUBSCRIPTIONS: {
+      craycraychannel: ['event-one', 'event-two']
+    },
+    eventOne: function(){ return "event-one-fired"; },
+    eventTwo: function(){ return "event-two-fired"; }
+  });
+
+  Ember.Application.initializer({
+    name: "registerFakeController",
+    initialize: function(container, application) {
+      container.register('controller:fake', FakeController);
+      targetController = container.lookup('controller:fake');
+    }
+  });
+
+  App = Ember.Application.create({
+    PUSHER_OPTS: { key: 'foo' }
+  });
 
   before(function(){
     pusherController = App.__container__.lookup('pusher:main');


### PR DESCRIPTION
In some cases, Pusher requires a channel name that includes a dash – for example in `presence-`
or `private-` channels. Due to ember-cli being very strict with JavaScript syntax, it is not
possible to use a dash in the channel names when configuring your `PUSHER_SUBSCRIPTIONS`.

To get around this, we allow the `PUSHER_OPTS` option of `dasherizeChannel`. When set to true,
the channel name in `PUSHER_SUBSCRIPTIONS` is dasherized. For instance, this is how you would build
a simple presence controller.

```javascript
PUSHER_OPTS: { key: 'foo', dasherizeChannel: true }

...
var YourController = Em.Controller.extend(EmberPusher.Bindings, {
  PUSHER_SUBSCRIPTIONS: {
    presenceMessages: ['member_added'],
  },
});
```

Added tests and updated the README to include this option.