### PR TITLE
Add a basic acceptance test for controller bindings

### DIFF
--- a/addon/services/pusher.js
+++ b/addon/services/pusher.js
@@ -93,7 +93,9 @@ export default Ember.Service.extend({
           console.log(target.constructor.toString() +
             ": Pusher event received", eventName, data);
         }
-        target.send(normalizedEventName, data);
+        Ember.run(() => {
+          target.send(normalizedEventName, data);
+        });
       };
 
       channel.bind(eventName, handler);

--- a/bower.json
+++ b/bower.json
@@ -11,6 +11,8 @@
     "ember-resolver": "~0.1.18",
     "jquery": "^1.11.3",
     "loader.js": "ember-cli/loader.js#3.2.1",
+    "pusher": "2.2.4",
+    "pusher-test-stub": "pusher-test-stub#2.0.0",
     "qunit": "~1.18.0"
   }
 }

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -6,12 +6,8 @@ module.exports = function(defaults) {
     // Add options here
   });
 
-  /*
-    This build file specifes the options for the dummy test app of this
-    addon, located in `/tests/dummy`
-    This build file does *not* influence how the addon or the app using it
-    behave. You most likely want to be modifying `./index.js` or app's build file
-  */
+  app.import('bower_components/pusher/dist/pusher.js');
+  app.import('bower_components/pusher-test-stub/dist/pusher-test-stub.js');
 
   return app.toTree();
 };

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "ember-cli-uglify": "^1.2.0",
     "ember-disable-proxy-controllers": "^1.0.0",
     "ember-export-application-global": "^1.0.3",
-    "ember-disable-prototype-extensions": "^1.0.0",
     "ember-try": "0.0.6"
   },
   "keywords": [

--- a/tests/.jshintrc
+++ b/tests/.jshintrc
@@ -1,5 +1,6 @@
 {
   "predef": [
+    "Pusher",
     "document",
     "window",
     "location",

--- a/tests/acceptance/controller-bindings-test.js
+++ b/tests/acceptance/controller-bindings-test.js
@@ -1,0 +1,32 @@
+import Ember from 'ember';
+import { module, test } from 'qunit';
+import startApp from '../helpers/start-app';
+
+module('Acceptance | Controller bindings', {
+  beforeEach: function() {
+    this.application = startApp();
+  },
+
+  afterEach: function() {
+    Ember.run(this.application, 'destroy');
+  }
+});
+
+function newMessage(message) {
+  return Pusher.singleton.trigger('controller-bindings', 'new-message', { message: message });
+}
+
+test('visiting /scenarios/controller-bindings', function(assert) {
+  visit('/scenarios/controller-bindings');
+  
+  andThen(() => {
+    assert.equal(currentURL(), '/scenarios/controller-bindings');
+
+    newMessage("Jamie");
+    assert.equal(find('.message-list-item').length, 1);
+
+    newMessage("rides");
+    newMessage("bikes");
+    assert.equal(find('.message-list-item').length, 3);
+  });
+});

--- a/tests/dummy/app/controllers/scenarios/controller-bindings.js
+++ b/tests/dummy/app/controllers/scenarios/controller-bindings.js
@@ -1,0 +1,23 @@
+import Ember from 'ember';
+import EmberPusher from 'ember-pusher';
+
+export default Ember.Controller.extend(EmberPusher.Bindings, {
+
+  PUSHER_SUBSCRIPTIONS: {
+    "controller-bindings": ['new-message']
+  },
+
+  messages: [],
+
+  actions: {
+    sendMessage(message) {
+      Pusher.singleton.trigger('controller-bindings', 'new-message', {
+        message: message
+      });
+    },
+
+    newMessage(data) {
+      this.messages.pushObject(data.message);
+    }
+  }
+});

--- a/tests/dummy/app/instance-initializers/ember-pusher.js
+++ b/tests/dummy/app/instance-initializers/ember-pusher.js
@@ -1,0 +1,9 @@
+export function initialize(instance) {
+  let pusherService = instance.container.lookup('service:pusher');
+  pusherService.setup('test-stub-key');
+}
+
+export default {
+  name: 'ember-pusher',
+  initialize: initialize
+};

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -6,6 +6,9 @@ var Router = Ember.Router.extend({
 });
 
 Router.map(function() {
+  this.route('scenarios', function() {
+    this.route('controller-bindings');
+  });
 });
 
 export default Router;

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -1,3 +1,9 @@
-<h2 id="title">Welcome to Ember</h2>
+<h2 id="title">ember-pusher test scenarios</h2>
+
+<ul>
+  <li>{{link-to "Controller bindings" 'scenarios.controller-bindings'}}</li>
+</ul>
+
+<hr>
 
 {{outlet}}

--- a/tests/dummy/app/templates/scenarios/controller-bindings.hbs
+++ b/tests/dummy/app/templates/scenarios/controller-bindings.hbs
@@ -1,0 +1,10 @@
+
+<p>Message: {{input class="message-input" value=message}}</p>
+<p><button {{action "sendMessage" message}}>Send</button></p>
+
+<h3>Messages ({{messages.length}})</h3>
+<ul class="message-list">
+  {{#each messages as |message|}}
+    <li class="message-list-item">{{message}}</li>
+  {{/each}}
+</ul>

--- a/tests/dummy/config/environment.js
+++ b/tests/dummy/config/environment.js
@@ -16,6 +16,16 @@ module.exports = function(environment) {
     APP: {
       // Here you can pass flags/options to your application instance
       // when it is created
+    },
+
+    contentSecurityPolicy: {
+      'default-src': "'none'",
+      'script-src': "'self' http://stats.pusher.com",
+      'font-src': "'self'",
+      'connect-src': "'self' ws://ws.pusherapp.com",
+      'img-src': "'self'",
+      'style-src': "'self'",
+      'media-src': "'self'"
     }
   };
 


### PR DESCRIPTION
- Adds a simple acceptance test using `pusher-test-stub`.
- Avoids an autorun when receiving an event from pusher.