### PR TITLE
Fallback to Ember.keys for Ember 1.x on IE8

### DIFF
--- a/addon/compat.js
+++ b/addon/compat.js
@@ -1,0 +1,3 @@
+import Ember from 'ember';
+
+export let keys = Object.keys || Ember.keys;

--- a/addon/mixins/bindings.js
+++ b/addon/mixins/bindings.js
@@ -1,9 +1,10 @@
 import Ember from 'ember';
+import { keys } from 'ember-pusher/compat';
 
 export default Ember.Mixin.create({
   init() {
     if (this.PUSHER_SUBSCRIPTIONS) {
-      Object.keys(this.PUSHER_SUBSCRIPTIONS).forEach(channelName => {
+      keys(this.PUSHER_SUBSCRIPTIONS).forEach(channelName => {
         let events = this.PUSHER_SUBSCRIPTIONS[channelName];
         this.pusher.wire(this, channelName, events);
       });
@@ -14,7 +15,7 @@ export default Ember.Mixin.create({
 
   willDestroy() {
     if (this.PUSHER_SUBSCRIPTIONS) {
-      Object.keys(this.PUSHER_SUBSCRIPTIONS).forEach(channelName => {
+      keys(this.PUSHER_SUBSCRIPTIONS).forEach(channelName => {
         this.pusher.unwire(this, channelName);
       });
     }

--- a/addon/services/pusher.js
+++ b/addon/services/pusher.js
@@ -1,4 +1,5 @@
 import Ember from 'ember';
+import { keys } from 'ember-pusher/compat';
 
 // Need to track
 // 1) channel object
@@ -121,7 +122,7 @@ export default Ember.Service.extend({
       bindings[channelName] = { eventBindings: {} };
     }
 
-    if (Ember.isEmpty(Object.keys(bindings[channelName].eventBindings))) {
+    if (Ember.isEmpty(keys(bindings[channelName].eventBindings))) {
       bindings[channelName].channel = pusher.subscribe(channelName);
 
       // Spit out a bunch of logging if asked
@@ -151,7 +152,7 @@ export default Ember.Service.extend({
     delete bindings[channelName].eventBindings[targetId];
 
     // Unsubscribe from the channel if this is the last thing listening
-    if (Object.keys(bindings[channelName].eventBindings).length === 0) {
+    if (keys(bindings[channelName].eventBindings).length === 0) {
       pusher.unsubscribe(channelName);
       delete bindings[channelName];
       return true;


### PR DESCRIPTION
`Ember.keys` is deprecated in 1.13 and removed in 2.0.

Related to #19.